### PR TITLE
Fixed disconnections not propagating

### DIFF
--- a/Chatlis-server/Headers/QClientConnection.h
+++ b/Chatlis-server/Headers/QClientConnection.h
@@ -9,7 +9,6 @@ class QClientConnection : public QSslSocket
 
 public:
 	QClientConnection(QObject* parent, qintptr socketDescriptor);
-	~QClientConnection();
 
 	void replicateExistingClients(const QList<QPair<QString, QString>>& existingClients);
 	void replicateClientMessage(const QString& clientName, const QString& message);
@@ -18,8 +17,10 @@ public:
 	void replicateClientNewUsername(const QString previousUsername, const QString computerName, const QString newUsername);
 	void replicateClientNewComputerName(const QString username, const QString previousComputerName, const QString newComputerName);
 
-	QString getClientUsername() const;
-	QString getClientComputerName() const;
+	[[nodiscard]] QString getClientUsername() const;
+	[[nodiscard]] QString getClientComputerName() const;
+	[[nodiscard]] bool getEncrypted() const;
+	void setEncrypted(bool encrypted);
 
 signals:
 	void newClient();
@@ -29,9 +30,10 @@ signals:
   
 public slots:
 	void receivedData();
+	void onEncrypted();
 
 private:
 	void sendNetworkMessage(const QByteArray& toSend);
-
+	bool isEncrypted;
 	QClientInfo client;
 };

--- a/Chatlis-server/Headers/QClientConnection.h
+++ b/Chatlis-server/Headers/QClientConnection.h
@@ -30,6 +30,8 @@ signals:
   
 public slots:
 	void receivedData();
+
+private slots:
 	void onEncrypted();
 
 private:

--- a/Chatlis-server/Headers/QClientConnection.h
+++ b/Chatlis-server/Headers/QClientConnection.h
@@ -20,7 +20,6 @@ public:
 	[[nodiscard]] QString getClientUsername() const;
 	[[nodiscard]] QString getClientComputerName() const;
 	[[nodiscard]] bool getEncrypted() const;
-	void setEncrypted(bool encrypted);
 
 signals:
 	void newClient();

--- a/Chatlis-server/Source/QChatlisServer-CLI.cpp
+++ b/Chatlis-server/Source/QChatlisServer-CLI.cpp
@@ -94,7 +94,7 @@ void QChatlisServer::clientDisconnected()
 {
 	QClientConnection* disconnectedClient{ dynamic_cast<QClientConnection*>(sender()) };
 	
-	if (disconnectedClient->isEncrypted())
+	if (disconnectedClient->getEncrypted())
 	{
 		const QString& username = disconnectedClient->getClientUsername();
 		const QString& computerName = disconnectedClient->getClientComputerName();

--- a/Chatlis-server/Source/QChatlisServer.cpp
+++ b/Chatlis-server/Source/QChatlisServer.cpp
@@ -88,7 +88,7 @@ void QChatlisServer::clientDisconnected()
 {
 	QClientConnection* disconnectedClient{ dynamic_cast<QClientConnection*>(sender()) };
 	
-	if (disconnectedClient->isEncrypted())
+	if (disconnectedClient->getEncrypted())
 	{
 		const QString& username = disconnectedClient->getClientUsername();
 		const QString& computerName = disconnectedClient->getClientComputerName();

--- a/Chatlis-server/Source/QClientConnection.cpp
+++ b/Chatlis-server/Source/QClientConnection.cpp
@@ -100,11 +100,6 @@ bool QClientConnection::getEncrypted() const
 	return isEncrypted;
 }
 
-void QClientConnection::setEncrypted(bool isEncrypted)
-{
-	this->isEncrypted = isEncrypted;
-}
-
 void QClientConnection::receivedData()
 {
 	QByteArray buffer;

--- a/Chatlis-server/Source/QClientConnection.cpp
+++ b/Chatlis-server/Source/QClientConnection.cpp
@@ -6,8 +6,9 @@
 #include <QSslCertificate>
 
 QClientConnection::QClientConnection(QObject* parent, qintptr socketDescriptor)
-	: QSslSocket(parent), client(false)
+	: QSslSocket(parent), client(false), isEncrypted{false}
 {
+	
 	QFile keyFile("SSL/server.key");
 	keyFile.open(QIODevice::ReadOnly);
 	QSslKey privateKey = QSslKey(keyFile.readAll(), QSsl::Rsa);
@@ -23,6 +24,7 @@ QClientConnection::QClientConnection(QObject* parent, qintptr socketDescriptor)
 	setSocketDescriptor(socketDescriptor);
 	startServerEncryption();
 
+	connect(this, &QSslSocket::encrypted, this, &QClientConnection::onEncrypted);
 	connect(this, &QClientConnection::readyRead, this, &QClientConnection::receivedData);
 }
 
@@ -93,6 +95,16 @@ QString QClientConnection::getClientComputerName() const
 	return client.getComputerName();
 }
 
+bool QClientConnection::getEncrypted() const
+{
+	return isEncrypted;
+}
+
+void QClientConnection::setEncrypted(bool isEncrypted)
+{
+	this->isEncrypted = isEncrypted;
+}
+
 void QClientConnection::receivedData()
 {
 	QByteArray buffer;
@@ -141,13 +153,14 @@ void QClientConnection::receivedData()
 	}
 }
 
+void QClientConnection::onEncrypted()
+{
+	setEncrypted(true);
+}
+
+
 void QClientConnection::sendNetworkMessage(const QByteArray& toSend)
 {
 	QDataStream dataStream(this);
 	dataStream << toSend;
-}
-
-QClientConnection::~QClientConnection() 
-{
-	qDebug("Delete QClient");
 }

--- a/Chatlis-server/Source/QClientConnection.cpp
+++ b/Chatlis-server/Source/QClientConnection.cpp
@@ -155,7 +155,7 @@ void QClientConnection::receivedData()
 
 void QClientConnection::onEncrypted()
 {
-	setEncrypted(true);
+	isEncrypted = true;
 }
 
 


### PR DESCRIPTION
- Added a isEncrypted boolean flag to QClientConnection.
- Added a connection between the encrypted signal and the new onEncrypted function that toggles the isEncrypted flag.
- Changed the server check for encryption status in the disconnection notification to use the new getEncrypted getter.

closes #35 